### PR TITLE
Dependency updates for 3.10.x

### DIFF
--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -15,7 +15,7 @@ Agent dependencies:
 * [PCRE](http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/) 8.41
 * [LMDB](https://github.com/LMDB/lmdb/) 0.9.21
 * [libyaml](http://pyyaml.org/wiki/LibYAML) 0.1.7
-* [libxml2](http://xmlsoft.org/sources/) 2.9.4
+* [libxml2](http://xmlsoft.org/sources/) 2.9.8
 * [libiconv](http://ftp.gnu.org/gnu/libiconv/) 1.15
   * Needed by libxml2
 * [libacl](http://download.savannah.gnu.org/releases/acl/) 2.2.52

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -32,7 +32,7 @@ Enterprise agent specific dependencies:
   for [redmine#2932](https://dev.cfengine.com/issues/2932)
   * Requires change of buildslaves (autobuild)
 * [pthreads-w32](ftp://sourceware.org/pub/pthreads-win32/) 2.9.1
-* [OpenLDAP](http://www.openldap.org/software/download/OpenLDAP/openldap-release/) 2.4.45
+* [OpenLDAP](http://www.openldap.org/software/download/OpenLDAP/openldap-release/) 2.4.46
 * [libvirt](http://libvirt.org/sources/stable_updates/) 1.1.3.9
 * [PostgreSQL](http://www.postgresql.org/) 9.0.23 **EOL**
   * From this one we selectively build only `libpq`

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -43,7 +43,7 @@ Hub specific dependencies:
 
 * [APR](https://apr.apache.org/) 1.5.2
 * [apr-util](https://apr.apache.org/) 1.5.4
-* [Apache](http://httpd.apache.org/) 2.4.27
+* [Apache](http://httpd.apache.org/) 2.4.29
 * [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.3
 * [Redis](http://redis.io/) 3.2.9
 * [PHP](http://php.net/) 5.6.31

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -45,7 +45,7 @@ Hub specific dependencies:
 * [apr-util](https://apr.apache.org/) 1.5.4
 * [Apache](http://httpd.apache.org/) 2.4.29
 * [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.9
-* [Redis](http://redis.io/) 3.2.9
+* [Redis](http://redis.io/) 3.2.12
 * [PHP](http://php.net/) 5.6.36
 * [libmcrypt](https://sourceforge.net/projects/mcrypt/files/Libmcrypt/) 2.5.8
   * Needed for php module

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -50,7 +50,7 @@ Hub specific dependencies:
 * [libmcrypt](https://sourceforge.net/projects/mcrypt/files/Libmcrypt/) 2.5.8
   * Needed for php module
 * [Git](https://www.kernel.org/pub/software/scm/git/) 2.13.3
-* [rsync](https://download.samba.org/pub/rsync/) 3.1.2
+* [rsync](https://download.samba.org/pub/rsync/) 3.1.3
 
 Other dependencies (**find out why they are needed!**)
 

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -44,7 +44,7 @@ Hub specific dependencies:
 * [APR](https://apr.apache.org/) 1.5.2
 * [apr-util](https://apr.apache.org/) 1.5.4
 * [Apache](http://httpd.apache.org/) 2.4.29
-* [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.3
+* [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.9
 * [Redis](http://redis.io/) 3.2.9
 * [PHP](http://php.net/) 5.6.31
 * [libmcrypt](https://sourceforge.net/projects/mcrypt/files/Libmcrypt/) 2.5.8

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -46,7 +46,7 @@ Hub specific dependencies:
 * [Apache](http://httpd.apache.org/) 2.4.29
 * [PostgreSQL](http://www.postgresql.org/) for the hub 9.6.9
 * [Redis](http://redis.io/) 3.2.9
-* [PHP](http://php.net/) 5.6.31
+* [PHP](http://php.net/) 5.6.36
 * [libmcrypt](https://sourceforge.net/projects/mcrypt/files/Libmcrypt/) 2.5.8
   * Needed for php module
 * [Git](https://www.kernel.org/pub/software/scm/git/) 2.13.3

--- a/deps-packaging/apache/cfbuild-apache.spec
+++ b/deps-packaging/apache/cfbuild-apache.spec
@@ -1,4 +1,4 @@
-%define apache_version 2.4.27
+%define apache_version 2.4.29
 %global __os_install_post %{nil}
 
 Summary: CFEngine Build Automation -- apache
@@ -89,3 +89,4 @@ CFEngine Build Automation -- apache -- development files
 %prefix/httpd/include
 
 %changelog
+

--- a/deps-packaging/apache/distfiles
+++ b/deps-packaging/apache/distfiles
@@ -1,1 +1,1 @@
-33c2543e6d337d6bbf50f18cfb318ce7  httpd-2.4.27.tar.gz
+feaa86fa25bb1e959c98d53d3edd9729  httpd-2.4.29.tar.gz

--- a/deps-packaging/libxml2/cfbuild-libxml2.spec
+++ b/deps-packaging/libxml2/cfbuild-libxml2.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- libxml2
 Name: cfbuild-libxml2
 Version: %{version}
 Release: 1
-Source0: libxml2-2.9.4.tar.gz
+Source0: libxml2-2.9.8.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n libxml2-2.9.4
+%setup -q -n libxml2-2.9.8
 
 ./configure --prefix=%{prefix} --without-python --enable-shared --disable-static --with-zlib=%{prefix} \
     CPPFLAGS="-I%{prefix}/include" \
@@ -70,3 +70,4 @@ CFEngine Build Automation -- libxml2 -- development files
 %prefix/lib/pkgconfig
 
 %changelog
+

--- a/deps-packaging/libxml2/distfiles
+++ b/deps-packaging/libxml2/distfiles
@@ -1,1 +1,1 @@
-ae249165c173b1ff386ee8ad676815f5  libxml2-2.9.4.tar.gz
+e63f10d75f770d4ee6ddf365ed884a60  libxml2-2.9.8.tar.gz

--- a/deps-packaging/openldap/cfbuild-openldap.spec
+++ b/deps-packaging/openldap/cfbuild-openldap.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- openldap
 Name: cfbuild-openldap
 Version: %{version}
 Release: 1
-Source0: openldap-2.4.45.tgz
+Source0: openldap-2.4.46.tgz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n openldap-2.4.45
+%setup -q -n openldap-2.4.46
 
 CPPFLAGS=-I%{buildprefix}/include
 
@@ -85,3 +85,4 @@ CFEngine Build Automation -- openldap -- development files
 %{prefix}/lib/*.so
 
 %changelog
+

--- a/deps-packaging/openldap/distfiles
+++ b/deps-packaging/openldap/distfiles
@@ -1,1 +1,1 @@
-00ff8301277cdfd0af728a6927042a13  openldap-2.4.45.tgz
+bdc6efccecdfebf713638648db93ccb8  openldap-2.4.46.tgz

--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -1,4 +1,4 @@
-%define php_version 5.6.31
+%define php_version 5.6.36
 
 Summary: CFEngine Build Automation -- php
 Name: cfbuild-php
@@ -188,3 +188,4 @@ CFEngine Build Automation -- php -- development files
 %prefix/httpd/php/include
 
 %changelog
+

--- a/deps-packaging/php/distfiles
+++ b/deps-packaging/php/distfiles
@@ -1,1 +1,1 @@
-40d4939e116c46cec0a486e2fab7c8b0  php-5.6.31.tar.gz
+31276562d34f3ea69d27aabcc10989e5  php-5.6.36.tar.gz

--- a/deps-packaging/postgresql-hub/cfbuild-postgresql-hub.spec
+++ b/deps-packaging/postgresql-hub/cfbuild-postgresql-hub.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- postgresql
 Name: cfbuild-postgresql
 Version: %{version}
 Release: 1
-Source0: postgresql-9.6.3.tar.gz
+Source0: postgresql-9.6.9.tar.gz
 Source1: postgresql.conf.cfengine
 License: MIT
 Group: Other
@@ -15,7 +15,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n postgresql-9.6.3
+%setup -q -n postgresql-9.6.9
 
 %build
 
@@ -204,3 +204,4 @@ CFEngine Build Automation -- postgresql -- dev files
 %{prefix}/lib/pkgconfig/*
 
 %changelog
+

--- a/deps-packaging/postgresql-hub/distfiles
+++ b/deps-packaging/postgresql-hub/distfiles
@@ -1,1 +1,1 @@
-183622c0f7e283ef47ca6831a2740ea8  postgresql-9.6.3.tar.gz
+5c29f9141a2e78b11f1ccc8d5126d301  postgresql-9.6.9.tar.gz

--- a/deps-packaging/postgresql-hub/source
+++ b/deps-packaging/postgresql-hub/source
@@ -1,1 +1,1 @@
-https://ftp.postgresql.org/pub/source/v9.6.3/
+https://ftp.postgresql.org/pub/source/v9.6.9/

--- a/deps-packaging/redis/cfbuild-redis.spec
+++ b/deps-packaging/redis/cfbuild-redis.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- redis
 Name: cfbuild-redis
 Version: %{version}
 Release: 1
-Source0: redis-3.2.9.tar.gz
+Source0: redis-3.2.12.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -21,7 +21,7 @@ AutoReqProv: no
 %prep
 mkdir -p %{_builddir}
 
-%setup -q -n redis-3.2.9
+%setup -q -n redis-3.2.12
 $PATCH -s -p1 < %{_topdir}/SOURCES/redis.patch
 
 %build
@@ -95,3 +95,4 @@ CFEngine Build Automation -- redis -- development files
 %{prefix}/include/hiredis/adapters/libevent.h
 
 %changelog
+

--- a/deps-packaging/redis/distfiles
+++ b/deps-packaging/redis/distfiles
@@ -1,1 +1,1 @@
-3d0a35985b4414c9376b6bcda0ef72ae  redis-3.2.9.tar.gz
+6231b3e2c34406aa3f408bb86a5261f2  redis-3.2.12.tar.gz

--- a/deps-packaging/rsync/cfbuild-rsync.spec
+++ b/deps-packaging/rsync/cfbuild-rsync.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- rsync
 Name: cfbuild-rsync
 Version: %{version}
 Release: 1
-Source0: rsync-3.1.2.tar.gz
+Source0: rsync-3.1.3.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n rsync-3.1.2
+%setup -q -n rsync-3.1.3
 
 ./configure --prefix=%{prefix} --with-included-zlib=%{prefix}
 
@@ -50,3 +50,4 @@ CFEngine Build Automation -- rsync -- development files
 %prefix/bin/rsync
 
 %changelog
+

--- a/deps-packaging/rsync/distfiles
+++ b/deps-packaging/rsync/distfiles
@@ -1,1 +1,1 @@
-0f758d7e000c0f7f7d3792610fad70cb  rsync-3.1.2.tar.gz
+9753b9d65add7daecda035b8279f694b  rsync-3.1.3.tar.gz


### PR DESCRIPTION
Update libxml2 from 2.9.4 to 2.9.8
Update openldap from 2.4.45 to 2.4.46
Update apache from 2.4.27 to 2.4.29
Update rsync from 3.1.2 to 3.1.3
Update postgresql-hub from 9.6.3 to 9.6.9
Update php from 5.6.31 to 5.6.36
Update redis from 3.2.9 to 3.2.12