### PR TITLE
Dependency updates for 3.7.x

### DIFF
--- a/build-scripts/transfer-to-testmachine
+++ b/build-scripts/transfer-to-testmachine
@@ -19,6 +19,12 @@ esac
 
 # Filter out "./" parts in the BASEDIR name.
 # It confuses the rsync -R mechanism.
-BASEDIR_NO_DOT="$(echo $BASEDIR | sed -e 's,/\.,,g')"
+# Explanation of sed script:
+# * first we replace "/./" with "/" anywhere in the BASEDIR
+# * then we remove "/." at the end of the BASEDIR
+# This way we avoid errorneously replacing "/." in the
+# middle of BASEDIR like "/home/jenkins/.jenkinsdir/etc"
+# (Google Cloud Jenkins plugin likes to create them)
+BASEDIR_NO_DOT="$(echo $BASEDIR | sed -e 's,/\./,/,g;s,/\.$,,')"
 sudo rsync -avR $EXCLUDES --delete --delete-excluded $BASEDIR_NO_DOT/ $TESTMACHINE_URI
 sudo rsync -avR $EXCLUDES --delete --delete-excluded /var/cfengine/ $TESTMACHINE_URI

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -48,7 +48,7 @@ Hub specific dependencies:
 * [Apache](http://httpd.apache.org/) 2.4.34
 * PostgreSQL for the hub 9.3.22
 * [Redis](http://redis.io/) 2.8.24
-* [PHP](http://php.net/) 5.6.35
+* [PHP](http://php.net/) 5.6.37
 * [libcurl](http://curl.haxx.se/download.html) 7.57.0
   * Needed for php module
 * libmcrypt 2.5.8

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -20,7 +20,7 @@ Agent dependencies:
 * [libiconv](http://ftp.gnu.org/gnu/libiconv/) 1.15
   * Needed by libxml2
 * [libacl](http://download.savannah.gnu.org/releases/acl/) 2.2.52
-* [libattr](http://download.savannah.gnu.org/releases/attr/) 2.4.47
+* [libattr](http://download.savannah.gnu.org/releases/attr/) 2.4.48
 * [MySQL](https://downloads.mysql.com/archives/community/) 5.1.72
 * [libcurl](http://curl.haxx.se/download.html) 7.61.0
 * libgcc

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -19,7 +19,7 @@ Agent dependencies:
 * [libxml2](http://xmlsoft.org/sources/) 2.9.8
 * [libiconv](http://ftp.gnu.org/gnu/libiconv/) 1.15
   * Needed by libxml2
-* [libacl](http://download.savannah.gnu.org/releases/acl/) 2.2.52
+* [libacl](http://download.savannah.gnu.org/releases/acl/) 2.2.53
 * [libattr](http://download.savannah.gnu.org/releases/attr/) 2.4.48
 * [MySQL](https://downloads.mysql.com/archives/community/) 5.1.72
 * [libcurl](http://curl.haxx.se/download.html) 7.61.0

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -45,7 +45,7 @@ Hub specific dependencies:
 
 * [APR](https://apr.apache.org/) 1.6.3
 * [apr-util](https://apr.apache.org/) 1.6.1
-* [Apache](http://httpd.apache.org/) 2.2.34
+* [Apache](http://httpd.apache.org/) 2.4.34
 * PostgreSQL for the hub 9.3.22
 * [Redis](http://redis.io/) 2.8.24
 * [PHP](http://php.net/) 5.6.35

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -43,7 +43,7 @@ Enterprise agent specific dependencies:
 
 Hub specific dependencies:
 
-* [APR](https://apr.apache.org/) 1.5.2
+* [APR](https://apr.apache.org/) 1.6.3
 * [apr-util](https://apr.apache.org/) 1.5.4
 * [Apache](http://httpd.apache.org/) 2.2.34
 * PostgreSQL for the hub 9.3.22

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -22,7 +22,7 @@ Agent dependencies:
 * [libacl](http://download.savannah.gnu.org/releases/acl/) 2.2.52
 * [libattr](http://download.savannah.gnu.org/releases/attr/) 2.4.47
 * [MySQL](https://downloads.mysql.com/archives/community/) 5.1.72
-* [libcurl](http://curl.haxx.se/download.html) 7.59.0
+* [libcurl](http://curl.haxx.se/download.html) 7.61.0
 * libgcc
   * Currently only in use on AIX, Solaris, GCC dynamically links to it in order
     to substitute missing system functions

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -44,7 +44,7 @@ Enterprise agent specific dependencies:
 Hub specific dependencies:
 
 * [APR](https://apr.apache.org/) 1.6.3
-* [apr-util](https://apr.apache.org/) 1.5.4
+* [apr-util](https://apr.apache.org/) 1.6.1
 * [Apache](http://httpd.apache.org/) 2.2.34
 * PostgreSQL for the hub 9.3.22
 * [Redis](http://redis.io/) 2.8.24

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -58,6 +58,6 @@ Hub specific dependencies:
 
 Other dependencies (**find out why they are needed!**)
 
-* [SASL2](https://cyrusimap.org/mediawiki/index.php/Downloads) 2.1.26
+* [SASL2](https://cyrusimap.org/mediawiki/index.php/Downloads) 2.1.27rc3
   * Only build on Solaris and HP-UX, why? What makes it necessary?
 

--- a/deps-packaging/README.md
+++ b/deps-packaging/README.md
@@ -15,7 +15,7 @@ Agent dependencies:
 * [OpenSSL](http://openssl.org/) 1.0.2o
 * [PCRE](http://ftp.csx.cam.ac.uk/pub/software/programming/pcre/) 8.42
 * [LMDB](https://github.com/LMDB/lmdb/) 0.9.22
-* [libyaml](http://pyyaml.org/wiki/LibYAML) 0.1.7
+* [libyaml](http://pyyaml.org/wiki/LibYAML) 0.2.1
 * [libxml2](http://xmlsoft.org/sources/) 2.9.8
 * [libiconv](http://ftp.gnu.org/gnu/libiconv/) 1.15
   * Needed by libxml2

--- a/deps-packaging/apache/cfbuild-apache.spec
+++ b/deps-packaging/apache/cfbuild-apache.spec
@@ -1,4 +1,4 @@
-%define apache_version 2.2.34
+%define apache_version 2.4.34
 %global __os_install_post %{nil}
 
 Summary: CFEngine Build Automation -- apache
@@ -80,3 +80,4 @@ CFEngine Build Automation -- apache -- development files
 %prefix/httpd/include
 
 %changelog
+

--- a/deps-packaging/apache/distfiles
+++ b/deps-packaging/apache/distfiles
@@ -1,1 +1,1 @@
-fc33e64a9d4bca2f7ef7023189cb5ee6  httpd-2.2.34.tar.gz
+6fe958874d2ebba99ac18d68b000ccb9  httpd-2.4.34.tar.gz

--- a/deps-packaging/apr-util/cfbuild-apr-util.spec
+++ b/deps-packaging/apr-util/cfbuild-apr-util.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- apr-util
 Name: cfbuild-apr-util
 Version: %{version}
 Release: 1
-Source0: apr-util-1.5.4.tar.gz
+Source0: apr-util-1.6.1.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n apr-util-1.5.4
+%setup -q -n apr-util-1.6.1
 
 CPPFLAGS=-I%{buildprefix}/include
 
@@ -95,3 +95,4 @@ CFEngine Build Automation -- apr -- development files
 %{prefix}/lib/*.so
 
 %changelog
+

--- a/deps-packaging/apr-util/distfiles
+++ b/deps-packaging/apr-util/distfiles
@@ -1,1 +1,1 @@
-866825c04da827c6e5f53daff5569f42  apr-util-1.5.4.tar.gz
+8636c4ea78b8dbbba22c89a9a9da2848  apr-util-1.6.1.tar.gz

--- a/deps-packaging/apr/cfbuild-apr.spec
+++ b/deps-packaging/apr/cfbuild-apr.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- apr
 Name: cfbuild-apr
 Version: %{version}
 Release: 1
-Source0: apr-1.5.2.tar.gz
+Source0: apr-1.6.3.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com/
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n apr-1.5.2
+%setup -q -n apr-1.6.3
 
 CPPFLAGS=-I%{buildprefix}/include
 
@@ -84,3 +84,4 @@ CFEngine Build Automation -- apr -- development files
 %{prefix}/lib/*.so
 %{prefix}/build-1
 %changelog
+

--- a/deps-packaging/apr/distfiles
+++ b/deps-packaging/apr/distfiles
@@ -1,1 +1,1 @@
-98492e965963f852ab29f9e61b2ad700  apr-1.5.2.tar.gz
+f55f39b622cc9887e9464e4e2753b1ac  apr-1.6.3.tar.gz

--- a/deps-packaging/lcov/cfbuild-lcov.spec
+++ b/deps-packaging/lcov/cfbuild-lcov.spec
@@ -1,11 +1,11 @@
 Summary: CFEngine Build Automation -- lcov
 Name: cfbuild-lcov
-Version: 1.10
+Version: 1.13
 Release: 1
 License: GPL
 Group: Development/Tools
 URL: http://ltp.sourceforge.net/coverage/lcov.php
-Source0: lcov-1.10.tar.gz
+Source0: lcov-1.13.tar.gz
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-root
 BuildArch: noarch
 Requires: perl >= 5.8.8
@@ -60,3 +60,4 @@ rm -rf $RPM_BUILD_ROOT
 - implemented variables for version/release
 * Fri Oct 8 2002 Peter Oberparleiter (Peter.Oberparleiter@de.ibm.com)
 - created initial spec file
+

--- a/deps-packaging/lcov/distfiles
+++ b/deps-packaging/lcov/distfiles
@@ -1,1 +1,1 @@
-b9fe33b921016fc68852c8a6beb3a3b5  lcov-1.10.tar.gz
+01c38c482918a5aa977b709f57bfa532  lcov-1.13.tar.gz

--- a/deps-packaging/lcov/source
+++ b/deps-packaging/lcov/source
@@ -1,1 +1,1 @@
-http://kent.dl.sourceforge.net/project/ltp/Coverage%20Analysis/LCOV-1.10/
+http://kent.dl.sourceforge.net/project/ltp/Coverage%20Analysis/LCOV-1.13/

--- a/deps-packaging/libacl/cfbuild-libacl.spec
+++ b/deps-packaging/libacl/cfbuild-libacl.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- libacl
 Name: cfbuild-libacl
 Version: %{version}
 Release: 1
-Source: acl-2.2.52.src.tar.gz
+Source: acl-2.2.53.src.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com
@@ -14,7 +14,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n acl-2.2.52
+%setup -q -n acl-2.2.53
 
 zcat ../../SOURCES/acl.destdir.diff.gz | $PATCH -p1 || true
 
@@ -67,3 +67,4 @@ CFEngine Build Automation -- libacl devel
 %prefix/lib/*.so
 
 %changelog
+

--- a/deps-packaging/libacl/distfiles
+++ b/deps-packaging/libacl/distfiles
@@ -1,1 +1,1 @@
-a61415312426e9c2212bd7dc7929abda  acl-2.2.52.src.tar.gz
+False  acl-2.2.53.src.tar.gz

--- a/deps-packaging/libattr/cfbuild-libattr.spec
+++ b/deps-packaging/libattr/cfbuild-libattr.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- libattr
 Name: cfbuild-libattr
 Version: %{version}
 Release: 1
-Source: attr-2.4.47.src.tar.gz
+Source: attr-2.4.48.src.tar.gz
 License: MIT
 Group: Other
 Url: http://example.com
@@ -15,7 +15,7 @@ AutoReqProv: no
 
 %prep
 mkdir -p %{_builddir}
-%setup -q -n attr-2.4.47
+%setup -q -n attr-2.4.48
 
 zcat ../../SOURCES/attr.destdir.diff.gz | $PATCH -p1 || true
 
@@ -64,3 +64,4 @@ CFEngine Build Automation -- libattr devel
 %prefix/lib/*.so
 
 %changelog 
+

--- a/deps-packaging/libattr/distfiles
+++ b/deps-packaging/libattr/distfiles
@@ -1,1 +1,1 @@
-84f58dec00b60f2dc8fd1c9709291cc7  attr-2.4.47.src.tar.gz
+False  attr-2.4.48.src.tar.gz

--- a/deps-packaging/libcurl/cfbuild-libcurl.spec
+++ b/deps-packaging/libcurl/cfbuild-libcurl.spec
@@ -1,4 +1,4 @@
-%define curl_version 7.59.0
+%define curl_version 7.61.0
 
 Summary: CFEngine Build Automation -- libcurl
 Name: cfbuild-libcurl
@@ -69,3 +69,4 @@ CFEngine Build Automation -- libcurl
 %prefix/lib/pkgconfig
 
 %changelog
+

--- a/deps-packaging/libcurl/distfiles
+++ b/deps-packaging/libcurl/distfiles
@@ -1,1 +1,1 @@
-a44f98c25c7506e7103039b542aa5ad8  curl-7.59.0.tar.gz
+d593dc97be682dbfbbc22f456f8a15d1  curl-7.61.0.tar.gz

--- a/deps-packaging/libyaml/cfbuild-libyaml.spec
+++ b/deps-packaging/libyaml/cfbuild-libyaml.spec
@@ -2,7 +2,7 @@ Summary: CFEngine Build Automation -- libyaml
 Name: cfbuild-libyaml
 Version: %{version}
 Release: 1
-Source0: yaml-0.1.7.tar.gz
+Source0: yaml-0.2.1.tar.gz
 License: MIT
 Group: Other
 BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
@@ -10,7 +10,7 @@ BuildRoot: %{_topdir}/BUILD/%{name}-%{version}-%{release}-buildroot
 AutoReqProv: no
 
 %define prefix %{buildprefix}
-%define srcdir yaml-0.1.7
+%define srcdir yaml-0.2.1
 
 %prep
 mkdir -p %{_builddir}
@@ -66,3 +66,4 @@ CFEngine Build Automation -- lmdb -- development files
 %{prefix}/lib/*.la
 
 %changelog
+

--- a/deps-packaging/libyaml/distfiles
+++ b/deps-packaging/libyaml/distfiles
@@ -1,1 +1,1 @@
-1abf45bd3a96374fa55ca63b32f9f2f9  yaml-0.1.7.tar.gz
+f1d0e322e837f62b3efd6263f207e1ab  yaml-0.2.1.tar.gz

--- a/deps-packaging/php/cfbuild-php.spec
+++ b/deps-packaging/php/cfbuild-php.spec
@@ -1,4 +1,4 @@
-%define php_version 5.6.35
+%define php_version 5.6.37
 
 Summary: CFEngine Build Automation -- php
 Name: cfbuild-php
@@ -191,3 +191,4 @@ CFEngine Build Automation -- php -- development files
 %prefix/httpd/php/include
 
 %changelog
+

--- a/deps-packaging/php/distfiles
+++ b/deps-packaging/php/distfiles
@@ -1,1 +1,1 @@
-aed69568b3cef4bf3de950ee84ee2cb2  php-5.6.35.tar.gz
+2470aaf317cec3c024f24de31d6802b7  php-5.6.37.tar.gz

--- a/deps-packaging/postgresql-hub/cfbuild-postgresql-hub.spec
+++ b/deps-packaging/postgresql-hub/cfbuild-postgresql-hub.spec
@@ -1,4 +1,4 @@
-%define postgresql_version 9.3.22
+%define postgresql_version 9.3.23
 
 Summary: CFEngine Build Automation -- postgresql
 Name: cfbuild-postgresql
@@ -407,3 +407,4 @@ CFEngine Build Automation -- postgresql -- contrib
 %{prefix}/lib/postgresql/dblink.so
 %{prefix}/lib/postgresql/pgrowlocks.so
 %changelog
+

--- a/deps-packaging/postgresql-hub/distfiles
+++ b/deps-packaging/postgresql-hub/distfiles
@@ -1,1 +1,1 @@
-4d627d1d4231508f6efaa43531a2a0d9  postgresql-9.3.22.tar.gz
+df25d0733c105e1488358f9806929cb2  postgresql-9.3.23.tar.gz

--- a/deps-packaging/postgresql-hub/source
+++ b/deps-packaging/postgresql-hub/source
@@ -1,1 +1,1 @@
-https://ftp.postgresql.org/pub/source/v9.3.22/
+https://ftp.postgresql.org/pub/source/v9.3.23/

--- a/deps-packaging/pthreads-w32/distfiles
+++ b/deps-packaging/pthreads-w32/distfiles
@@ -1,1 +1,1 @@
-36ba827d6aa0fa9f9ae740a35626e2e3  pthreads-w32-2-9-1-release.tar.gz
+False  pthreads-w32--2-9-1-release.tar.gz-release.tar.gz

--- a/deps-packaging/sasl2/distfiles
+++ b/deps-packaging/sasl2/distfiles
@@ -1,1 +1,1 @@
-a7f4e5e559a0e37b3ffc438c9456e425  cyrus-sasl-2.1.26.tar.gz
+False  cyrus-sasl-2.1.27rc3.tar.gz


### PR DESCRIPTION
Update lcov from 1.10 to 1.13
Update pthreads-w32 from 2-9-1 to -2-9-1-release.tar.gz
Update sasl2 from 2.1.26 to 2.1.27rc3
Update libcurl from 7.59.0 to 7.61.0
Update apr from 1.5.2 to 1.6.3
Update apr-util from 1.5.4 to 1.6.1
Update apache from 2.2.34 to 2.4.34
Update postgresql-hub from 9.3.22 to 9.3.23
Update php from 5.6.35 to 5.6.37
Update libattr from 2.4.47 to 2.4.48
Update libacl from 2.2.52 to 2.2.53
Update libyaml from 0.1.7 to 0.2.1